### PR TITLE
Fix out of bound access in libziparchive

### DIFF
--- a/libziparchive/zip_archive.cc
+++ b/libziparchive/zip_archive.cc
@@ -463,9 +463,14 @@ static int32_t MapCentralDirectory0(int fd, const char* debug_file_name,
    * Grab the CD offset and size, and the number of entries in the
    * archive and verify that they look reasonable.
    */
-  if (eocd->cd_start_offset + eocd->cd_size > eocd_offset) {
+  if (static_cast<off64_t>(eocd->cd_start_offset) + eocd->cd_size > eocd_offset) {
     ALOGW("Zip: bad offsets (dir %" PRIu32 ", size %" PRIu32 ", eocd %" PRId64 ")",
         eocd->cd_start_offset, eocd->cd_size, static_cast<int64_t>(eocd_offset));
+#if defined(__ANDROID__)
+    if (eocd->cd_start_offset + eocd->cd_size <= eocd_offset) {
+      android_errorWriteLog(0x534e4554, "31251826");
+    }
+#endif
     return kInvalidOffset;
   }
   if (eocd->num_records == 0) {


### PR DESCRIPTION
The boundary check of an invalid EOCD record may succeed due to the
overflow of uint32_t. Fix the check.

Test: Open the crash.apk and libziparchive reports the offset error as expected.

CYNGNOS-3312
Bug: 31251826
Change-Id: I1d8092a19b73886a671bc9d291cfc27d65e3d236
(cherry picked from commit ae8180c06dee228cd1378c56afa6020ae98d8a24)
(cherry picked from commit 1ee4892e66ba314131b7ecf17e98bb1762c4b84c)
(cherry picked from commit 7f246f7fdd2f003c6f3701f599052a2040af6bfb)